### PR TITLE
Add compatibility with PHP8

### DIFF
--- a/sharedinfo.php
+++ b/sharedinfo.php
@@ -5,7 +5,7 @@ $startTime = microtime(true);
 /**
  * Throw exceptions on php errors
  */
-set_error_handler(function($errno, $errstr, $errfile, $errline, $errcontext)
+set_error_handler(function($errno, $errstr, $errfile, $errline)
 {
     // error was suppressed with the @-operator
     if (0 === error_reporting())


### PR DESCRIPTION
Parameter `errcontext` in callback function for `set_error_handler()` has been deprecated since PHP 7.2 and has been removed in PHP 8.

See https://www.php.net/manual/en/function.set-error-handler.php